### PR TITLE
Adds support for Eddystone UID

### DIFF
--- a/eddystone_uid.go
+++ b/eddystone_uid.go
@@ -1,0 +1,17 @@
+package beacon
+
+// BeaconTypeEddystoneUID indicates a beacon of type Eddystone-UID.
+const BeaconTypeEddystoneUID = "eddystone_uid"
+
+// NewEddystoneUIDBeacon returns an Eddystone-UID beacon or an error if
+// the namespace or instance are invalid hex strings or the wrong length.
+func NewEddystoneUIDBeacon(namespace string, instance string, pwr int8) (*Beacon, error) {
+	beaconIds := EddystoneUIDFields(namespace, instance)
+
+	beacon := NewBeacon(BeaconTypeEddystoneUID,
+		beaconIds,          // ids
+		Fields{},           // data
+		FieldFromInt8(pwr), // measured power
+	)
+	return &beacon, nil
+}

--- a/eddystone_uid_test.go
+++ b/eddystone_uid_test.go
@@ -1,0 +1,15 @@
+package beacon
+
+import "testing"
+
+func TestNewEddystoneUIDBeacon(t *testing.T) {
+	namespace := "00010203040506070809"
+	instance := "00010203040506"
+	beacon, error := NewEddystoneUIDBeacon(namespace, instance, -42)
+	if error != nil {
+		t.Error("Unable to create Eddystone UID beacon")
+	}
+	if beacon.Type != BeaconTypeEddystoneUID {
+		t.Errorf("Beacon type %v; expected %v", beacon.Type, BeaconTypeEddystoneUID)
+	}
+}


### PR DESCRIPTION
Adds support for creating an Eddystone UID beacon to be advertised.

Noticed during development that `beacon.EddystoneUIDFields` function already exists. Since it accepts `string` arguments, I expected it would return an error if one of the arguments was either invalid hex or the wrong length for the argument (namespace ID being 10 bytes, instance ID being 6 bytes).  Returning an error would contemplate adding an error to the return of `beacon.FieldFromHex` which would cause a bit of a ripple effect.  Worth dealing with, @syoder?