### PR TITLE
Add a few fields to ScanData

### DIFF
--- a/ble112/device.go
+++ b/ble112/device.go
@@ -207,9 +207,19 @@ loop:
 			}
 			if r.IsAdvertisement() {
 				if r.IsMfgAd() {
-					data <- beacon.ScanData{r.Data[20:], r.MacAddress().String(), r.RSSI(), &r.Data}
+					data <- beacon.ScanData{
+						Bytes:  r.Data[20:],
+						Device: r.MacAddress().String(),
+						RSSI:   r.RSSI(),
+						Raw:    &r.Data,
+					}
 				} else {
-					data <- beacon.ScanData{r.Data[24:], r.MacAddress().String(), r.RSSI(), &r.Data}
+					data <- beacon.ScanData{
+						Bytes:  r.Data[24:],
+						Device: r.MacAddress().String(),
+						RSSI:   r.RSSI(),
+						Raw:    &r.Data,
+					}
 				}
 			}
 		case <-done:

--- a/scanner.go
+++ b/scanner.go
@@ -17,10 +17,13 @@ type Scanner struct {
 
 // ScanData represents a possible beacon advertisement that can be parsed into a beacon
 type ScanData struct {
-	Bytes  []byte
-	Device string
-	RSSI   int8
-	Raw    *[]byte
+	Bytes       []byte
+	Device      string
+	AddressType uint8
+	AdvType     uint8
+	Channel     uint8
+	RSSI        int8
+	Raw         *[]byte
 }
 
 // A ScanDevice will return ScanData on a channel.  Currently the only implementation is


### PR DESCRIPTION
This allows scanners to return additional information like advertisement type, address type and channel.