### PR TITLE
Add tests for MAC address representations

### DIFF
--- a/mac_address_test.go
+++ b/mac_address_test.go
@@ -1,0 +1,85 @@
+package beacon
+
+import (
+	"testing"
+)
+
+type mac struct {
+	hex  string
+	bits [6]byte
+	text []byte
+}
+
+var testCases []mac
+
+func init() {
+	testCases = []mac{
+		{
+			"fe:fd:55:c9:64:24",
+			[6]byte{0x24, 0x64, 0xc9, 0x55, 0xfd, 0xfe},
+			[]byte{'"', 'f', 'e', ':', 'f', 'd', ':', '5', '5', ':', 'c', '9', ':', '6', '4', ':', '2', '4', '"'},
+		},
+		{
+			"29:fe:fd:41:21:20",
+			[6]byte{0x20, 0x21, 0x41, 0xfd, 0xfe, 0x29},
+			[]byte{'"', '2', '9', ':', 'f', 'e', ':', 'f', 'd', ':', '4', '1', ':', '2', '1', ':', '2', '0', '"'},
+		},
+	}
+}
+
+func TestMacString(t *testing.T) {
+	for _, tc := range testCases {
+		result := MacAddress(tc.bits).String()
+		if result != tc.hex {
+			t.Errorf("result %s; want %s", result, tc.hex)
+		}
+	}
+}
+
+func TestMacMarshalJSON(t *testing.T) {
+	for _, tc := range testCases {
+		result, _ := MacAddress(tc.bits).MarshalJSON()
+		if !lenEqual(result, tc.text) {
+			t.Errorf("result %s; want %s", result, tc.text)
+		}
+		if !valueEqual(result, tc.text) {
+			t.Errorf("result %s; want %s", result, tc.text)
+		}
+	}
+}
+
+func TestMacUnmarshalJSON(t *testing.T) {
+	for _, tc := range testCases {
+		addr := MacAddress{}
+		addr.UnmarshalJSON(tc.text)
+		if addr != tc.bits {
+			t.Errorf("result %s; want %v", addr, tc.hex)
+		}
+	}
+}
+
+func TestParseMacAddress(t *testing.T) {
+	for _, tc := range testCases {
+		want := MacAddress(tc.bits)
+		result := ParseMacAddress(tc.hex)
+		if result != want {
+			t.Errorf("result %s; want %s", result, want)
+		}
+	}
+}
+
+func lenEqual(r []byte, t []byte) bool {
+	return len(r) == len(t)
+}
+
+func valueEqual(r []byte, t []byte) (equal bool) {
+	for i, v := range r {
+		if v == t[i] {
+			equal = true
+		} else {
+			equal = false
+			break
+		}
+	}
+	return equal
+}


### PR DESCRIPTION
Adds tests to verify MAC Address conversion to different types of representations.

Successful tests:

```bash
% go test
PASS
ok  	github.com/RadiusNetworks/go-beacon	0.006s
```

Changing the data to show failing tests.

```diff
diff --git a/mac_address_test.go b/mac_address_test.go
index 6015091..7e0f12a 100644
--- a/mac_address_test.go
+++ b/mac_address_test.go
@@ -15,14 +15,14 @@ var testCases []mac
 func init() {
        testCases = []mac{
                {
-                       "fe:fd:55:c9:64:24",
+                       "be:fd:55:c9:64:24",
                        [6]byte{0x24, 0x64, 0xc9, 0x55, 0xfd, 0xfe},
-                       []byte{'"', 'f', 'e', ':', 'f', 'd', ':', '5', '5', ':', 'c', '9', ':', '6', '4', ':', '2', '4', '"'},
+                       []byte{'"', 'd', 'e', ':', 'f', 'd', ':', '5', '5', ':', 'c', '9', ':', '6', '4', ':', '2', '4', '"'},
                },
                {
-                       "29:fe:fd:41:21:20",
+                       "2b:fe:fd:41:21:20",
                        [6]byte{0x20, 0x21, 0x41, 0xfd, 0xfe, 0x29},
-                       []byte{'"', '2', '9', ':', 'f', 'e', ':', 'f', 'd', ':', '4', '1', ':', '2', '1', ':', '2', '0', '"'},
+                       []byte{'"', 'd', '9', ':', 'f', 'e', ':', 'f', 'd', ':', '4', '1', ':', '2', '1', ':', '2', '0', '"'},
                },
        }
 }
```

```bash
% go test
--- FAIL: TestMacString (0.00s)
    mac_address_test.go:34: result fe:fd:55:c9:64:24; want be:fd:55:c9:64:24
    mac_address_test.go:34: result 29:fe:fd:41:21:20; want 2b:fe:fd:41:21:20
--- FAIL: TestMacMarshalJSON (0.00s)
    mac_address_test.go:46: result "fe:fd:55:c9:64:24"; want "de:fd:55:c9:64:24"
    mac_address_test.go:46: result "29:fe:fd:41:21:20"; want "d9:fe:fd:41:21:20"
--- FAIL: TestMacUnmarshalJSON (0.00s)
    mac_address_test.go:56: result de:fd:55:c9:64:24; want be:fd:55:c9:64:24
    mac_address_test.go:56: result d9:fe:fd:41:21:20; want 2b:fe:fd:41:21:20
--- FAIL: TestParseMacAddress (0.00s)
    mac_address_test.go:66: result be:fd:55:c9:64:24; want fe:fd:55:c9:64:24
    mac_address_test.go:66: result 2b:fe:fd:41:21:20; want 29:fe:fd:41:21:20
FAIL
exit status 1
FAIL	github.com/RadiusNetworks/go-beacon	0.006s
```

